### PR TITLE
feat: rename timeBehind field to timeDifference in API responses

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -162,12 +162,12 @@ func (h *Handler) GetResults(c *gin.Context) {
 			Position:   position,
 			Name:       comp.Name,
 			Club:       comp.Club.Name,
-			StartTime:  comp.StartTime,
-			FinishTime: comp.FinishTime,
-			Time:       &timeStr,
-			Status:     "OK",
-			TimeBehind: timeBehind,
-			RadioTimes: radioTimes,
+			StartTime:      comp.StartTime,
+			FinishTime:     comp.FinishTime,
+			Time:           &timeStr,
+			Status:         "OK",
+			TimeDifference: timeBehind,
+			RadioTimes:     radioTimes,
 		})
 		position++
 	}
@@ -305,13 +305,13 @@ func (h *Handler) GetSplits(c *gin.Context) {
 			}
 
 			standing.Standings = append(standing.Standings, SplitTime{
-				Position:    position,
-				Name:        entry.competitor.Name,
-				Club:        entry.competitor.Club.Name,
-				SplitTime:   entry.splitTime,
-				ElapsedTime: &elapsedStr,
-				TimeBehind:  timeBehind,
-				Status:      "OK",
+				Position:       position,
+				Name:           entry.competitor.Name,
+				Club:           entry.competitor.Club.Name,
+				SplitTime:      entry.splitTime,
+				ElapsedTime:    &elapsedStr,
+				TimeDifference: timeBehind,
+				Status:         "OK",
 			})
 			position++
 		}

--- a/internal/handlers/types.go
+++ b/internal/handlers/types.go
@@ -17,15 +17,15 @@ type StartListEntry struct {
 }
 
 type ResultEntry struct {
-	Position   int         `json:"position"`
-	Name       string      `json:"name"`
-	Club       string      `json:"club"`
-	StartTime  time.Time   `json:"startTime"`
-	FinishTime *time.Time  `json:"finishTime,omitempty"`
-	Time       *string     `json:"time,omitempty"`
-	Status     string      `json:"status"`
-	TimeBehind *string     `json:"timeBehind,omitempty"`
-	RadioTimes []RadioTime `json:"radioTimes,omitempty"`
+	Position       int         `json:"position"`
+	Name           string      `json:"name"`
+	Club           string      `json:"club"`
+	StartTime      time.Time   `json:"startTime"`
+	FinishTime     *time.Time  `json:"finishTime,omitempty"`
+	Time           *string     `json:"time,omitempty"`
+	Status         string      `json:"status"`
+	TimeDifference *string     `json:"timeDifference,omitempty"`
+	RadioTimes     []RadioTime `json:"radioTimes,omitempty"`
 }
 
 type RadioTime struct {
@@ -35,13 +35,13 @@ type RadioTime struct {
 }
 
 type SplitTime struct {
-	Position    int        `json:"position"`
-	Name        string     `json:"name"`
-	Club        string     `json:"club"`
-	SplitTime   *time.Time `json:"splitTime,omitempty"`
-	ElapsedTime *string    `json:"elapsedTime,omitempty"`
-	TimeBehind  *string    `json:"timeBehind,omitempty"`
-	Status      string     `json:"status"`
+	Position        int        `json:"position"`
+	Name            string     `json:"name"`
+	Club            string     `json:"club"`
+	SplitTime       *time.Time `json:"splitTime,omitempty"`
+	ElapsedTime     *string    `json:"elapsedTime,omitempty"`
+	TimeDifference  *string    `json:"timeDifference,omitempty"`
+	Status          string     `json:"status"`
 }
 
 type SplitStanding struct {


### PR DESCRIPTION
## Summary
- Renames the API response field from `timeBehind` to `timeDifference` to match the specification in issue #6
- Updates both the results and split standings endpoints to use the new field name
- The time difference functionality was already implemented - this PR only updates the field naming

## Test plan
- [x] Build project successfully
- [x] Run existing tests
- [ ] Test split standings endpoint shows `timeDifference` field
- [ ] Test results endpoint shows `timeDifference` field
- [ ] Verify leader shows null for `timeDifference`
- [ ] Verify other positions show time difference with "+" prefix

Closes #6