### PR TITLE
feat: add configurable timing for simulation mode

### DIFF
--- a/cmd/meos-graphics/main.go
+++ b/cmd/meos-graphics/main.go
@@ -39,6 +39,22 @@ func run(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("poll interval too large (maximum 1 hour): %s", cmd.PollInterval)
 	}
 
+	// Check if simulation timing flags are used without simulation mode
+	if !cmd.SimulationMode {
+		// Check if any non-default simulation timing values are set
+		defaultDuration := 15 * time.Minute
+		defaultPhaseStart := 3 * time.Minute
+		defaultPhaseRunning := 7 * time.Minute
+		defaultPhaseResults := 5 * time.Minute
+
+		if cmd.SimulationDuration != defaultDuration ||
+			cmd.SimulationPhaseStart != defaultPhaseStart ||
+			cmd.SimulationPhaseRunning != defaultPhaseRunning ||
+			cmd.SimulationPhaseResults != defaultPhaseResults {
+			return fmt.Errorf("simulation timing flags can only be used with --simulation mode")
+		}
+	}
+
 	if err := logger.Init(); err != nil {
 		return fmt.Errorf("failed to initialize logger: %v", err)
 	}
@@ -46,6 +62,33 @@ func run(_ *cobra.Command, _ []string) error {
 	logger.InfoLogger.Printf("Starting MeOS Graphics API Server v%s", version.Version)
 	if cmd.SimulationMode {
 		logger.InfoLogger.Println("Running in SIMULATION MODE")
+
+		// Validate simulation timing configuration
+		if cmd.SimulationDuration <= 0 {
+			return fmt.Errorf("simulation duration must be positive: %s", cmd.SimulationDuration)
+		}
+
+		// Validate each phase duration is positive
+		if cmd.SimulationPhaseStart <= 0 {
+			return fmt.Errorf("simulation-phase-start must be positive: %s", cmd.SimulationPhaseStart)
+		}
+		if cmd.SimulationPhaseRunning <= 0 {
+			return fmt.Errorf("simulation-phase-running must be positive: %s", cmd.SimulationPhaseRunning)
+		}
+		if cmd.SimulationPhaseResults <= 0 {
+			return fmt.Errorf("simulation-phase-results must be positive: %s", cmd.SimulationPhaseResults)
+		}
+
+		// Validate phase durations sum to total duration
+		phaseSum := cmd.SimulationPhaseStart + cmd.SimulationPhaseRunning + cmd.SimulationPhaseResults
+		if phaseSum != cmd.SimulationDuration {
+			return fmt.Errorf("phase durations (%s + %s + %s = %s) must equal total duration (%s)",
+				cmd.SimulationPhaseStart, cmd.SimulationPhaseRunning, cmd.SimulationPhaseResults,
+				phaseSum, cmd.SimulationDuration)
+		}
+
+		logger.InfoLogger.Printf("Simulation timing: Total=%s, Start=%s, Running=%s, Results=%s",
+			cmd.SimulationDuration, cmd.SimulationPhaseStart, cmd.SimulationPhaseRunning, cmd.SimulationPhaseResults)
 	}
 
 	// Initialize global state
@@ -59,8 +102,9 @@ func run(_ *cobra.Command, _ []string) error {
 	}
 
 	if cmd.SimulationMode {
-		// Use simulation adapter
-		adapter = simulation.NewAdapter(appState)
+		// Use simulation adapter with timing configuration
+		adapter = simulation.NewAdapter(appState, cmd.SimulationDuration,
+			cmd.SimulationPhaseStart, cmd.SimulationPhaseRunning, cmd.SimulationPhaseResults)
 	} else {
 		// Configure MeOS adapter
 		config := meos.NewConfig()

--- a/docs/CLI_FLAGS.md
+++ b/docs/CLI_FLAGS.md
@@ -37,6 +37,30 @@ meos-graphics [flags]
 
 - **Description**: Run in simulation mode
 
+### --simulation-duration
+
+- **Type**: duration
+- **Default**: 15m0s
+- **Description**: Total simulation cycle duration (only with --simulation)
+
+### --simulation-phase-results
+
+- **Type**: duration
+- **Default**: 5m0s
+- **Description**: Duration of results phase (only with --simulation)
+
+### --simulation-phase-running
+
+- **Type**: duration
+- **Default**: 7m0s
+- **Description**: Duration of running phase (only with --simulation)
+
+### --simulation-phase-start
+
+- **Type**: duration
+- **Default**: 3m0s
+- **Description**: Duration of start list phase (only with --simulation)
+
 ## Examples
 
 ### Run in simulation mode

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -12,6 +12,12 @@ var (
 	PollInterval   time.Duration
 	MeosHost       string
 	MeosPort       string
+
+	// Simulation timing configuration
+	SimulationDuration     time.Duration
+	SimulationPhaseStart   time.Duration
+	SimulationPhaseRunning time.Duration
+	SimulationPhaseResults time.Duration
 )
 
 // NewRootCommand creates and returns the root cobra command
@@ -32,6 +38,12 @@ The server can run in two modes:
 	rootCmd.Flags().DurationVar(&PollInterval, "poll-interval", 1*time.Second, "Poll interval for MeOS data updates (e.g., 200ms, 9s, 2m)")
 	rootCmd.Flags().StringVar(&MeosHost, "meos-host", "localhost", "MeOS server hostname or IP address")
 	rootCmd.Flags().StringVar(&MeosPort, "meos-port", "2009", "MeOS server port (use 'none' to omit port from URL)")
+
+	// Simulation timing flags
+	rootCmd.Flags().DurationVar(&SimulationDuration, "simulation-duration", 15*time.Minute, "Total simulation cycle duration (only with --simulation)")
+	rootCmd.Flags().DurationVar(&SimulationPhaseStart, "simulation-phase-start", 3*time.Minute, "Duration of start list phase (only with --simulation)")
+	rootCmd.Flags().DurationVar(&SimulationPhaseRunning, "simulation-phase-running", 7*time.Minute, "Duration of running phase (only with --simulation)")
+	rootCmd.Flags().DurationVar(&SimulationPhaseResults, "simulation-phase-results", 5*time.Minute, "Duration of results phase (only with --simulation)")
 
 	return rootCmd
 }

--- a/internal/simulation/adapter_test.go
+++ b/internal/simulation/adapter_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewAdapter(t *testing.T) {
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	if adapter == nil {
 		t.Fatal("NewAdapter() returned nil")
@@ -33,7 +33,7 @@ func TestAdapter_Connect(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	err := adapter.Connect()
 	if err != nil {
@@ -84,7 +84,7 @@ func TestAdapter_Connect(t *testing.T) {
 
 func TestAdapter_StartPolling_NotConnected(t *testing.T) {
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	// Should not error when not connected
 	err := adapter.StartPolling()
@@ -100,7 +100,7 @@ func TestAdapter_StartPolling_Connected(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	// Connect first
 	err := adapter.Connect()
@@ -130,7 +130,7 @@ func TestAdapter_Stop(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	// Connect and start polling
 	adapter.Connect()
@@ -166,7 +166,7 @@ func TestAdapter_UpdateSimulation(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	// Connect to initialize data
 	adapter.Connect()
@@ -199,7 +199,7 @@ func TestAdapter_SimulationCycle(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	// Connect to initialize
 	adapter.Connect()
@@ -260,7 +260,7 @@ func TestAdapter_ConcurrentAccess(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	// Connect and start
 	adapter.Connect()
@@ -308,7 +308,7 @@ func TestAdapter_ResetBehavior(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	adapter.Connect()
 
@@ -353,7 +353,7 @@ func TestAdapter_StateConsistency(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	adapter.Connect()
 
@@ -406,7 +406,7 @@ func BenchmarkAdapter_UpdateSimulation(b *testing.B) {
 	logger.Init()
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 	adapter.Connect()
 
 	b.ResetTimer()
@@ -421,7 +421,7 @@ func BenchmarkAdapter_StateRead(b *testing.B) {
 	logger.Init()
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 	adapter.Connect()
 
 	b.ResetTimer()

--- a/internal/simulation/generator_test.go
+++ b/internal/simulation/generator_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestNewGenerator(t *testing.T) {
-	g := NewGenerator()
+	g := NewGenerator(15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 	if g == nil {
-		t.Fatal("NewGenerator() returned nil")
+		t.Fatal("NewGenerator(15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute) returned nil")
 	}
 	if g.rnd == nil {
 		t.Error("Generator random source is nil")
@@ -20,7 +20,7 @@ func TestNewGenerator(t *testing.T) {
 }
 
 func TestGenerator_GenerateInitialData(t *testing.T) {
-	g := NewGenerator()
+	g := NewGenerator(15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 	baseTime := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 
 	event, controls, classes, clubs, competitors := g.GenerateInitialData(baseTime)
@@ -154,8 +154,20 @@ func TestGenerator_DeterministicOutput(t *testing.T) {
 	baseTime := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 
 	// Create two generators with same seed
-	g1 := &Generator{rnd: rand.New(rand.NewSource(12345))}
-	g2 := &Generator{rnd: rand.New(rand.NewSource(12345))}
+	g1 := &Generator{
+		rnd:          rand.New(rand.NewSource(12345)),
+		duration:     15 * time.Minute,
+		phaseStart:   3 * time.Minute,
+		phaseRunning: 7 * time.Minute,
+		phaseResults: 5 * time.Minute,
+	}
+	g2 := &Generator{
+		rnd:          rand.New(rand.NewSource(12345)),
+		duration:     15 * time.Minute,
+		phaseStart:   3 * time.Minute,
+		phaseRunning: 7 * time.Minute,
+		phaseResults: 5 * time.Minute,
+	}
 
 	_, _, _, _, competitors1 := g1.GenerateInitialData(baseTime)
 	_, _, _, _, competitors2 := g2.GenerateInitialData(baseTime)
@@ -176,7 +188,7 @@ func TestGenerator_DeterministicOutput(t *testing.T) {
 }
 
 func TestGenerator_PhaseTransitions(t *testing.T) {
-	g := NewGenerator()
+	g := NewGenerator(15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 	baseTime := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 
 	g.GenerateInitialData(baseTime)
@@ -294,7 +306,7 @@ func TestGenerator_PhaseTransitions(t *testing.T) {
 }
 
 func TestGenerator_SimulationReset(t *testing.T) {
-	g := NewGenerator()
+	g := NewGenerator(15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 	baseTime := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 
 	g.GenerateInitialData(baseTime)
@@ -333,7 +345,7 @@ func TestGenerator_SimulationReset(t *testing.T) {
 }
 
 func TestGenerator_TimeCalculations(t *testing.T) {
-	g := NewGenerator()
+	g := NewGenerator(15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 	baseTime := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 
 	g.GenerateInitialData(baseTime)
@@ -378,7 +390,7 @@ func TestGenerator_TimeCalculations(t *testing.T) {
 }
 
 func TestGenerator_CompetitorProgression(t *testing.T) {
-	g := NewGenerator()
+	g := NewGenerator(15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 	baseTime := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 
 	g.GenerateInitialData(baseTime)
@@ -428,7 +440,7 @@ func TestGenerator_CompetitorProgression(t *testing.T) {
 }
 
 func TestGenerator_SplitTimeConsistency(t *testing.T) {
-	g := NewGenerator()
+	g := NewGenerator(15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 	baseTime := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 
 	g.GenerateInitialData(baseTime)
@@ -478,7 +490,7 @@ func minOfThree(a, b, c int) int {
 }
 
 func TestGenerator_ClassSpecificRadioControls(t *testing.T) {
-	g := NewGenerator()
+	g := NewGenerator(15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 	baseTime := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 
 	g.GenerateInitialData(baseTime)

--- a/internal/simulation/integration_test.go
+++ b/internal/simulation/integration_test.go
@@ -17,7 +17,7 @@ func TestSimulationFullCycle(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	// Use deterministic generator for predictable tests
 	adapter.generator.rnd = rand.New(rand.NewSource(12345))
@@ -151,7 +151,7 @@ func TestSimulationProgressionInvariants(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	// Use deterministic generator
 	adapter.generator.rnd = rand.New(rand.NewSource(54321))
@@ -241,7 +241,7 @@ func TestSimulationDeterminism(t *testing.T) {
 
 	for run := 0; run < 2; run++ {
 		appState := state.New()
-		adapter := NewAdapter(appState)
+		adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 		adapter.generator.rnd = rand.New(rand.NewSource(seed))
 
 		// Override the base time to be deterministic
@@ -301,7 +301,7 @@ func TestSimulationPerformance(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 	adapter.Connect()
 
 	baseTime := appState.GetEvent().Start
@@ -335,7 +335,7 @@ func TestSimulationStateManagement(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 
 	// Test before connection
 	if adapter.connected {
@@ -377,7 +377,7 @@ func TestSimulationDataIntegrity(t *testing.T) {
 	}
 
 	appState := state.New()
-	adapter := NewAdapter(appState)
+	adapter := NewAdapter(appState, 15*time.Minute, 3*time.Minute, 7*time.Minute, 5*time.Minute)
 	adapter.Connect()
 
 	baseTime := appState.GetEvent().Start

--- a/internal/simulation/timing_test.go
+++ b/internal/simulation/timing_test.go
@@ -1,0 +1,274 @@
+package simulation
+
+import (
+	"testing"
+	"time"
+
+	"meos-graphics/internal/logger"
+	"meos-graphics/internal/state"
+)
+
+// TestConfigurableTiming tests simulation with different timing configurations
+func TestConfigurableTiming(t *testing.T) {
+	// Initialize logger
+	if err := logger.Init(); err != nil {
+		t.Fatalf("Failed to initialize logger: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		duration       time.Duration
+		phaseStart     time.Duration
+		phaseRunning   time.Duration
+		phaseResults   time.Duration
+		testTimePoints []struct {
+			elapsed       time.Duration
+			expectedPhase string
+		}
+	}{
+		{
+			name:         "Default 15min cycle",
+			duration:     15 * time.Minute,
+			phaseStart:   3 * time.Minute,
+			phaseRunning: 7 * time.Minute,
+			phaseResults: 5 * time.Minute,
+			testTimePoints: []struct {
+				elapsed       time.Duration
+				expectedPhase string
+			}{
+				{1 * time.Minute, "start"},
+				{4 * time.Minute, "running"},
+				{11 * time.Minute, "results"},
+				{16 * time.Minute, "reset"},
+			},
+		},
+		{
+			name:         "Quick 1min test cycle",
+			duration:     1 * time.Minute,
+			phaseStart:   10 * time.Second,
+			phaseRunning: 30 * time.Second,
+			phaseResults: 20 * time.Second,
+			testTimePoints: []struct {
+				elapsed       time.Duration
+				expectedPhase string
+			}{
+				{5 * time.Second, "start"},
+				{20 * time.Second, "running"},
+				{50 * time.Second, "results"},
+				{70 * time.Second, "reset"},
+			},
+		},
+		{
+			name:         "Sprint event 5min cycle",
+			duration:     5 * time.Minute,
+			phaseStart:   1 * time.Minute,
+			phaseRunning: 2 * time.Minute,
+			phaseResults: 2 * time.Minute,
+			testTimePoints: []struct {
+				elapsed       time.Duration
+				expectedPhase string
+			}{
+				{30 * time.Second, "start"},
+				{90 * time.Second, "running"},
+				{4 * time.Minute, "results"},
+				{6 * time.Minute, "reset"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appState := state.New()
+			adapter := NewAdapter(appState, tt.duration, tt.phaseStart, tt.phaseRunning, tt.phaseResults)
+
+			// Verify timing configuration was set
+			if adapter.duration != tt.duration {
+				t.Errorf("Duration = %v, want %v", adapter.duration, tt.duration)
+			}
+			if adapter.phaseStart != tt.phaseStart {
+				t.Errorf("PhaseStart = %v, want %v", adapter.phaseStart, tt.phaseStart)
+			}
+			if adapter.phaseRunning != tt.phaseRunning {
+				t.Errorf("PhaseRunning = %v, want %v", adapter.phaseRunning, tt.phaseRunning)
+			}
+			if adapter.phaseResults != tt.phaseResults {
+				t.Errorf("PhaseResults = %v, want %v", adapter.phaseResults, tt.phaseResults)
+			}
+
+			adapter.Connect()
+			baseTime := appState.GetEvent().Start
+
+			for _, tp := range tt.testTimePoints {
+				currentTime := baseTime.Add(tp.elapsed)
+				competitors := adapter.generator.UpdateSimulation(currentTime)
+
+				// Count statuses
+				statusCounts := map[string]int{"0": 0, "9": 0, "1": 0}
+				for _, comp := range competitors {
+					statusCounts[comp.Status]++
+				}
+
+				// Verify expected phase behavior
+				switch tp.expectedPhase {
+				case "start":
+					// All should be not started
+					if statusCounts["9"] > 0 || statusCounts["1"] > 0 {
+						t.Errorf("%s at %v: Expected all not started, got %d running, %d finished",
+							tt.name, tp.elapsed, statusCounts["9"], statusCounts["1"])
+					}
+				case "running":
+					// Some should be running or finished
+					if statusCounts["9"]+statusCounts["1"] == 0 {
+						t.Errorf("%s at %v: Expected some progress, all still not started",
+							tt.name, tp.elapsed)
+					}
+				case "results":
+					// Most/all should be finished
+					if statusCounts["1"] < len(competitors)/2 {
+						t.Errorf("%s at %v: Expected most finished, only %d/%d finished",
+							tt.name, tp.elapsed, statusCounts["1"], len(competitors))
+					}
+				case "reset":
+					// All should be back to not started
+					if statusCounts["0"] != len(competitors) {
+						t.Errorf("%s at %v: Expected all reset, got %d not started, %d running, %d finished",
+							tt.name, tp.elapsed, statusCounts["0"], statusCounts["9"], statusCounts["1"])
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestTimingValidation tests that timing validation works correctly
+func TestTimingValidation(t *testing.T) {
+	// This test verifies that the main.go validation logic would catch invalid configurations
+	// The actual validation is done in main.go, but we can test the behavior here
+
+	tests := []struct {
+		name         string
+		duration     time.Duration
+		phaseStart   time.Duration
+		phaseRunning time.Duration
+		phaseResults time.Duration
+		shouldWork   bool
+	}{
+		{
+			name:         "Valid equal sum",
+			duration:     10 * time.Minute,
+			phaseStart:   2 * time.Minute,
+			phaseRunning: 5 * time.Minute,
+			phaseResults: 3 * time.Minute,
+			shouldWork:   true,
+		},
+		{
+			name:         "Invalid sum too large",
+			duration:     10 * time.Minute,
+			phaseStart:   3 * time.Minute,
+			phaseRunning: 5 * time.Minute,
+			phaseResults: 3 * time.Minute,
+			shouldWork:   false, // 3+5+3=11 > 10
+		},
+		{
+			name:         "Invalid sum too small",
+			duration:     10 * time.Minute,
+			phaseStart:   2 * time.Minute,
+			phaseRunning: 4 * time.Minute,
+			phaseResults: 3 * time.Minute,
+			shouldWork:   false, // 2+4+3=9 < 10
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sum := tt.phaseStart + tt.phaseRunning + tt.phaseResults
+			isValid := sum == tt.duration && tt.duration > 0 &&
+				tt.phaseStart > 0 && tt.phaseRunning > 0 && tt.phaseResults > 0
+
+			if isValid != tt.shouldWork {
+				t.Errorf("Validation result = %v, want %v (duration=%v, sum=%v)",
+					isValid, tt.shouldWork, tt.duration, sum)
+			}
+		})
+	}
+}
+
+// TestPhaseLogging tests that phase boundaries work correctly
+func TestPhaseLogging(t *testing.T) {
+	// Initialize logger
+	if err := logger.Init(); err != nil {
+		t.Fatalf("Failed to initialize logger: %v", err)
+	}
+
+	appState := state.New()
+	adapter := NewAdapter(appState, 3*time.Minute, 30*time.Second, 90*time.Second, 60*time.Second)
+	adapter.Connect()
+
+	baseTime := appState.GetEvent().Start
+
+	// Test phase boundaries
+	testPoints := []struct {
+		elapsed            time.Duration
+		expectedNotStarted int
+		expectedRunning    int
+		expectedFinished   int
+		description        string
+	}{
+		{0, -1, 0, 0, "start list phase"},
+		{29 * time.Second, -1, 0, 0, "still in start phase"},
+		{30 * time.Second, -1, -1, -1, "running phase begins"},
+		{2 * time.Minute, -1, -1, -1, "results phase begins"},
+		{2*time.Minute + 59*time.Second, -1, -1, -1, "still in results phase"},
+		{3*time.Minute + 1*time.Second, -1, 0, 0, "after reset"},
+	}
+
+	totalCompetitors := len(adapter.generator.competitors)
+
+	for _, tp := range testPoints {
+		currentTime := baseTime.Add(tp.elapsed)
+		competitors := adapter.generator.UpdateSimulation(currentTime)
+
+		// Count statuses
+		notStarted := 0
+		running := 0
+		finished := 0
+
+		for _, comp := range competitors {
+			switch comp.Status {
+			case "0":
+				notStarted++
+			case "9":
+				running++
+			case "1":
+				finished++
+			}
+		}
+
+		// Check expectations (-1 means we don't care about exact count)
+		if tp.expectedNotStarted >= 0 && notStarted != tp.expectedNotStarted {
+			t.Errorf("At %v (%s): notStarted = %d, want %d", tp.elapsed, tp.description, notStarted, tp.expectedNotStarted)
+		}
+		if tp.expectedRunning >= 0 && running != tp.expectedRunning {
+			t.Errorf("At %v (%s): running = %d, want %d", tp.elapsed, tp.description, running, tp.expectedRunning)
+		}
+		if tp.expectedFinished >= 0 && finished != tp.expectedFinished {
+			t.Errorf("At %v (%s): finished = %d, want %d", tp.elapsed, tp.description, finished, tp.expectedFinished)
+		}
+
+		// For start phases, all should be not started
+		if tp.description == "start list phase" || tp.description == "still in start phase" {
+			if notStarted != totalCompetitors {
+				t.Errorf("At %v (%s): expected all %d competitors not started, but %d are",
+					tp.elapsed, tp.description, totalCompetitors, notStarted)
+			}
+		}
+
+		// After reset, all should be not started again
+		if tp.description == "after reset" {
+			if notStarted != totalCompetitors {
+				t.Errorf("At %v (%s): expected all %d competitors reset to not started, but only %d are",
+					tp.elapsed, tp.description, totalCompetitors, notStarted)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Implements configurable timing for simulation mode as requested in #16. Users can now customize phase durations when running the simulation.

## Changes
- Added command-line flags for simulation timing configuration
- Implemented comprehensive validation for timing parameters
- Updated simulation generator and adapter to use configurable timing
- Added tests for timing configuration and validation
- Auto-generated updated CLI documentation

## New Flags
- `--simulation-duration` (default: 15m): Total simulation cycle duration
- `--simulation-phase-start` (default: 3m): Duration of start list phase
- `--simulation-phase-running` (default: 7m): Duration of running phase
- `--simulation-phase-results` (default: 5m): Duration of results phase

## Usage Examples

### Default 15-minute cycle
```bash
go run ./cmd/meos-graphics --simulation
```

### Quick 1-minute test cycle
```bash
go run ./cmd/meos-graphics --simulation \
  --simulation-duration=1m \
  --simulation-phase-start=10s \
  --simulation-phase-running=30s \
  --simulation-phase-results=20s
```

### Sprint event timing (5 minutes)
```bash
go run ./cmd/meos-graphics --simulation \
  --simulation-duration=5m \
  --simulation-phase-start=1m \
  --simulation-phase-running=2m \
  --simulation-phase-results=2m
```

## Validation
- Timing flags can only be used with `--simulation` mode
- All durations must be positive
- Phase durations must sum to exactly the total duration

## Test plan
- [x] Added unit tests for configurable timing
- [x] Added validation tests
- [x] Updated existing tests to use new constructor signatures
- [x] All tests pass
- [x] Pre-commit hooks pass

Closes #16