### PR TITLE
feat: clean up REST API endpoints to return only necessary data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,6 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -159,16 +159,14 @@ func TestHandler_GetStartList(t *testing.T) {
 		t.Errorf("Number of start list entries = %d, want 3", len(startList))
 	}
 
-	// Verify sorting by start time and start numbers
+	// Verify sorting by start time
 	if len(startList) >= 3 {
 		if startList[0].Name != "John Doe" {
 			t.Errorf("First starter = %q, want %q", startList[0].Name, "John Doe")
 		}
-		if startList[0].StartNumber != 1 {
-			t.Errorf("First start number = %d, want 1", startList[0].StartNumber)
-		}
-		if startList[2].StartNumber != 3 {
-			t.Errorf("Last start number = %d, want 3", startList[2].StartNumber)
+		// Check start time formatting
+		if startList[0].StartTime != "11:00" {
+			t.Errorf("First start time = %q, want %q", startList[0].StartTime, "11:00")
 		}
 	}
 }
@@ -268,16 +266,11 @@ func TestHandler_GetResults(t *testing.T) {
 		if results[0].Name != "John Doe" {
 			t.Errorf("First place name = %q, want %q", results[0].Name, "John Doe")
 		}
-		if results[0].Time == nil {
-			t.Error("First place time should not be nil")
-		} else if *results[0].Time != "1:23.4" {
-			t.Errorf("First place time = %q, want %q", *results[0].Time, "1:23.4")
+		if results[0].RunningTime != "1:23.4" {
+			t.Errorf("First place time = %q, want %q", results[0].RunningTime, "1:23.4")
 		}
-		if results[0].TimeDifference != nil {
+		if results[0].Difference != "" {
 			t.Error("First place should not have time difference")
-		}
-		if len(results[0].RadioTimes) != 2 {
-			t.Errorf("First place radio times = %d, want 2", len(results[0].RadioTimes))
 		}
 	}
 
@@ -286,10 +279,8 @@ func TestHandler_GetResults(t *testing.T) {
 		if results[1].Position != 2 {
 			t.Errorf("Second position = %d, want 2", results[1].Position)
 		}
-		if results[1].TimeDifference == nil {
-			t.Error("Second place time difference should not be nil")
-		} else if *results[1].TimeDifference != "+0:07.8" {
-			t.Errorf("Second place time difference = %q, want %q", *results[1].TimeDifference, "+0:07.8")
+		if results[1].Difference != "+0:07.8" {
+			t.Errorf("Second place time difference = %q, want %q", results[1].Difference, "+0:07.8")
 		}
 	}
 
@@ -304,8 +295,8 @@ func TestHandler_GetResults(t *testing.T) {
 			if result.Position != 0 {
 				t.Error("DNF should not have position")
 			}
-			if result.Time != nil {
-				t.Error("DNF should not have time")
+			if result.RunningTime != "" {
+				t.Error("DNF should not have running time")
 			}
 		case "MP":
 			mpFound = true
@@ -519,37 +510,8 @@ func TestHandler_RadioTimeCalculation(t *testing.T) {
 		t.Fatalf("Expected 1 result, got %d", len(results))
 	}
 
-	radioTimes := results[0].RadioTimes
-	if len(radioTimes) != 3 {
-		t.Fatalf("Expected 3 radio times, got %d", len(radioTimes))
-	}
-
-	// Check split times calculation
-	expectedSplits := []struct {
-		control     string
-		elapsedTime string
-		splitTime   string
-	}{
-		{"Control 1", "0:30.2", "0:30.2"},
-		{"Control 2", "0:58.4", "0:28.2"},
-		{"Control 3", "1:32.3", "0:33.9"},
-	}
-
-	for i, expected := range expectedSplits {
-		if i >= len(radioTimes) {
-			break
-		}
-		rt := radioTimes[i]
-		if rt.ControlName != expected.control {
-			t.Errorf("Radio time %d control = %q, want %q", i, rt.ControlName, expected.control)
-		}
-		if rt.ElapsedTime != expected.elapsedTime {
-			t.Errorf("Radio time %d elapsed = %q, want %q", i, rt.ElapsedTime, expected.elapsedTime)
-		}
-		if rt.SplitTime != expected.splitTime {
-			t.Errorf("Radio time %d split = %q, want %q", i, rt.SplitTime, expected.splitTime)
-		}
-	}
+	// Radio times are no longer included in results endpoint
+	// as per the API cleanup requirement
 }
 
 func TestHandler_ConcurrentRequests(t *testing.T) {

--- a/internal/web/templates/partials.templ
+++ b/internal/web/templates/partials.templ
@@ -2,13 +2,8 @@ package templates
 
 import (
 	"meos-graphics/internal/service"
-	"time"
 	"fmt"
 )
-
-func formatTime(t time.Time) string {
-	return t.Format("15:04:05")
-}
 
 func formatDuration(d *string) string {
 	if d == nil {
@@ -29,7 +24,6 @@ templ StartListPartial(startList []service.StartListEntry) {
 					<th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
 					<th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Club</th>
 					<th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Start Time</th>
-					<th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Card</th>
 				</tr>
 			</thead>
 			<tbody class="bg-white divide-y divide-gray-200">
@@ -37,14 +31,7 @@ templ StartListPartial(startList []service.StartListEntry) {
 					<tr>
 						<td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{ competitor.Name }</td>
 						<td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{ competitor.Club }</td>
-						<td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{ formatTime(competitor.StartTime) }</td>
-						<td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-							if competitor.Card != 0 {
-								{ fmt.Sprint(competitor.Card) }
-							} else {
-								-
-							}
-						</td>
+						<td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{ competitor.StartTime }</td>
 					</tr>
 				}
 			</tbody>
@@ -83,14 +70,14 @@ templ ResultsPartial(results []service.ResultEntry) {
 						<td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{ result.Name }</td>
 						<td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{ result.Club }</td>
 						<td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-							if hasValue(result.Time) {
-								{ formatDuration(result.Time) }
+							if result.RunningTime != "" {
+								{ result.RunningTime }
 							} else {
 								-
 							}
 						</td>
 						<td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-							{ formatDuration(result.TimeDifference) }
+							{ result.Difference }
 						</td>
 						<td class="px-6 py-4 whitespace-nowrap text-sm">
 							<span class={ "inline-flex rounded-full px-2 text-xs font-semibold leading-5", getStatusBadgeClass(result.Status) }>


### PR DESCRIPTION
## Summary
- Implements issue #31 to clean up REST API endpoints
- Reduces payload size by returning only necessary fields
- Improves API clarity and performance

## Changes

### StartList endpoint (`/classes/:id/startlist`)
- Now returns only: `Name`, `Club`, and `StartTime` (formatted as HH:mm)
- Removed: `StartNumber`, `Card`, and raw time fields

### Results endpoint (`/classes/:id/results`) 
- Now returns only: `Name`, `Club`, `Status`, `RunningTime`, `Position`, and `Difference`
- Removed: `StartTime`, `FinishTime`, and `RadioTimes` (use splits endpoint for control times)

### Splits endpoint (`/classes/:id/splits`)
- Removed: `Status` and `SplitTime` fields from split standings
- Kept: Position-based timing data and differences

## Impact
- **Breaking change**: API response structures have changed
- Web interface updated to work with new response formats
- All tests updated and passing

## Testing
- All unit tests pass
- Pre-commit hooks pass (lint, build, test, swagger)
- Manual testing recommended for external consumers

Fixes #31