### PR TITLE
fix: add templ generation to release workflow and update version to 1.0.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,12 +27,18 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.23'
+          
+      - name: Install templ
+        if: ${{ steps.release.outputs.release_created }}
+        run: go install github.com/a-h/templ/cmd/templ@latest
           
       - name: Build
         if: ${{ steps.release.outputs.release_created }}
         run: |
           go mod download
+          templ generate
+          mkdir -p dist
           GOOS=linux GOARCH=amd64 go build -o dist/meos-graphics-linux-amd64 ./cmd/meos-graphics
           GOOS=windows GOARCH=amd64 go build -o dist/meos-graphics-windows-amd64.exe ./cmd/meos-graphics
           GOOS=darwin GOARCH=amd64 go build -o dist/meos-graphics-darwin-amd64 ./cmd/meos-graphics

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,7 +31,7 @@ jobs:
           
       - name: Install templ
         if: ${{ steps.release.outputs.release_created }}
-        run: go install github.com/a-h/templ/cmd/templ@latest
+        run: go install github.com/a-h/templ/cmd/templ@v0.3.865
           
       - name: Build
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,10 @@ jobs:
     
     - name: Check Swagger documentation is up-to-date
       run: |
+        # Create a dummy go file to help swag find the module name
+        echo "package main" > doc.go
         swag init -g cmd/meos-graphics/main.go --parseDependency --parseInternal
+        rm doc.go
         ./scripts/validate-swagger.sh
         git diff --exit-code docs/swagger.json docs/swagger.yaml docs/docs.go || \
           (echo "Swagger documentation is out of date. Run 'swag init -g cmd/meos-graphics/main.go' and commit the changes." && exit 1)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.23'
     
     - name: Install templ
-      run: go install github.com/a-h/templ/cmd/templ@latest
+      run: go install github.com/a-h/templ/cmd/templ@v0.3.865
     
     - name: Generate templ files
       run: templ generate

--- a/cmd/meos-graphics/main.go
+++ b/cmd/meos-graphics/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 // @title meos-graphics
-// @version 0.0.0 x-release-please-version
+// @version 1.0.0 x-release-please-version
 // @description REST API for accessing orienteering competition data from MeOS
 // @termsOfService http://swagger.io/terms/
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -43,7 +43,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/meos-graphics_internal_service.ClassInfo"
+                                "$ref": "#/definitions/service.ClassInfo"
                             }
                         }
                     }
@@ -78,7 +78,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/meos-graphics_internal_service.ResultEntry"
+                                "$ref": "#/definitions/service.ResultEntry"
                             }
                         }
                     },
@@ -129,7 +129,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/meos-graphics_internal_service.SplitsResponse"
+                            "$ref": "#/definitions/service.SplitsResponse"
                         }
                     },
                     "400": {
@@ -181,7 +181,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/meos-graphics_internal_service.StartListEntry"
+                                "$ref": "#/definitions/service.StartListEntry"
                             }
                         }
                     },
@@ -208,7 +208,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "meos-graphics_internal_service.ClassInfo": {
+        "service.ClassInfo": {
             "type": "object",
             "properties": {
                 "id": {
@@ -222,7 +222,7 @@ const docTemplate = `{
                 }
             }
         },
-        "meos-graphics_internal_service.ResultEntry": {
+        "service.ResultEntry": {
             "type": "object",
             "properties": {
                 "club": {
@@ -247,7 +247,7 @@ const docTemplate = `{
                 }
             }
         },
-        "meos-graphics_internal_service.SplitStanding": {
+        "service.SplitStanding": {
             "type": "object",
             "properties": {
                 "controlId": {
@@ -259,12 +259,12 @@ const docTemplate = `{
                 "standings": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/meos-graphics_internal_service.SplitTime"
+                        "$ref": "#/definitions/service.SplitTime"
                     }
                 }
             }
         },
-        "meos-graphics_internal_service.SplitTime": {
+        "service.SplitTime": {
             "type": "object",
             "properties": {
                 "club": {
@@ -284,7 +284,7 @@ const docTemplate = `{
                 }
             }
         },
-        "meos-graphics_internal_service.SplitsResponse": {
+        "service.SplitsResponse": {
             "type": "object",
             "properties": {
                 "className": {
@@ -293,12 +293,12 @@ const docTemplate = `{
                 "splits": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/meos-graphics_internal_service.SplitStanding"
+                        "$ref": "#/definitions/service.SplitStanding"
                     }
                 }
             }
         },
-        "meos-graphics_internal_service.StartListEntry": {
+        "service.StartListEntry": {
             "type": "object",
             "properties": {
                 "club": {
@@ -318,7 +318,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "0.0.0 x-release-please-version",
+	Version:          "1.0.0 x-release-please-version",
 	Host:             "localhost:8090",
 	BasePath:         "/",
 	Schemes:          []string{"http", "https"},

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -17,7 +17,7 @@
             "name": "MIT",
             "url": "https://opensource.org/licenses/MIT"
         },
-        "version": "0.0.0 x-release-please-version"
+        "version": "1.0.0 x-release-please-version"
     },
     "host": "localhost:8090",
     "basePath": "/",
@@ -41,7 +41,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/meos-graphics_internal_service.ClassInfo"
+                                "$ref": "#/definitions/service.ClassInfo"
                             }
                         }
                     }
@@ -76,7 +76,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/meos-graphics_internal_service.ResultEntry"
+                                "$ref": "#/definitions/service.ResultEntry"
                             }
                         }
                     },
@@ -127,7 +127,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/meos-graphics_internal_service.SplitsResponse"
+                            "$ref": "#/definitions/service.SplitsResponse"
                         }
                     },
                     "400": {
@@ -179,7 +179,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/meos-graphics_internal_service.StartListEntry"
+                                "$ref": "#/definitions/service.StartListEntry"
                             }
                         }
                     },
@@ -206,7 +206,7 @@
         }
     },
     "definitions": {
-        "meos-graphics_internal_service.ClassInfo": {
+        "service.ClassInfo": {
             "type": "object",
             "properties": {
                 "id": {
@@ -220,7 +220,7 @@
                 }
             }
         },
-        "meos-graphics_internal_service.ResultEntry": {
+        "service.ResultEntry": {
             "type": "object",
             "properties": {
                 "club": {
@@ -245,7 +245,7 @@
                 }
             }
         },
-        "meos-graphics_internal_service.SplitStanding": {
+        "service.SplitStanding": {
             "type": "object",
             "properties": {
                 "controlId": {
@@ -257,12 +257,12 @@
                 "standings": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/meos-graphics_internal_service.SplitTime"
+                        "$ref": "#/definitions/service.SplitTime"
                     }
                 }
             }
         },
-        "meos-graphics_internal_service.SplitTime": {
+        "service.SplitTime": {
             "type": "object",
             "properties": {
                 "club": {
@@ -282,7 +282,7 @@
                 }
             }
         },
-        "meos-graphics_internal_service.SplitsResponse": {
+        "service.SplitsResponse": {
             "type": "object",
             "properties": {
                 "className": {
@@ -291,12 +291,12 @@
                 "splits": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/meos-graphics_internal_service.SplitStanding"
+                        "$ref": "#/definitions/service.SplitStanding"
                     }
                 }
             }
         },
-        "meos-graphics_internal_service.StartListEntry": {
+        "service.StartListEntry": {
             "type": "object",
             "properties": {
                 "club": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,6 +1,6 @@
 basePath: /
 definitions:
-  meos-graphics_internal_service.ClassInfo:
+  service.ClassInfo:
     properties:
       id:
         type: integer
@@ -9,7 +9,7 @@ definitions:
       orderKey:
         type: integer
     type: object
-  meos-graphics_internal_service.ResultEntry:
+  service.ResultEntry:
     properties:
       club:
         type: string
@@ -26,7 +26,7 @@ definitions:
       status:
         type: string
     type: object
-  meos-graphics_internal_service.SplitStanding:
+  service.SplitStanding:
     properties:
       controlId:
         type: integer
@@ -34,10 +34,10 @@ definitions:
         type: string
       standings:
         items:
-          $ref: '#/definitions/meos-graphics_internal_service.SplitTime'
+          $ref: '#/definitions/service.SplitTime'
         type: array
     type: object
-  meos-graphics_internal_service.SplitTime:
+  service.SplitTime:
     properties:
       club:
         type: string
@@ -50,16 +50,16 @@ definitions:
       timeDifference:
         type: string
     type: object
-  meos-graphics_internal_service.SplitsResponse:
+  service.SplitsResponse:
     properties:
       className:
         type: string
       splits:
         items:
-          $ref: '#/definitions/meos-graphics_internal_service.SplitStanding'
+          $ref: '#/definitions/service.SplitStanding'
         type: array
     type: object
-  meos-graphics_internal_service.StartListEntry:
+  service.StartListEntry:
     properties:
       club:
         type: string
@@ -81,7 +81,7 @@ info:
     url: https://opensource.org/licenses/MIT
   termsOfService: http://swagger.io/terms/
   title: meos-graphics
-  version: 0.0.0 x-release-please-version
+  version: 1.0.0 x-release-please-version
 paths:
   /classes:
     get:
@@ -95,7 +95,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/meos-graphics_internal_service.ClassInfo'
+              $ref: '#/definitions/service.ClassInfo'
             type: array
       summary: Get all competition classes
       tags:
@@ -119,7 +119,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/meos-graphics_internal_service.ResultEntry'
+              $ref: '#/definitions/service.ResultEntry'
             type: array
         "400":
           description: Bad Request
@@ -153,7 +153,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/meos-graphics_internal_service.SplitsResponse'
+            $ref: '#/definitions/service.SplitsResponse'
         "400":
           description: Bad Request
           schema:
@@ -187,7 +187,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/meos-graphics_internal_service.StartListEntry'
+              $ref: '#/definitions/service.StartListEntry'
             type: array
         "400":
           description: Bad Request

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,6 +2,6 @@ package version
 
 // Version is the current version of the application
 // x-release-please-start-version
-const Version = "0.0.0"
+const Version = "1.0.0"
 
 // x-release-please-end


### PR DESCRIPTION
## Summary
- Add templ installation and generation steps before building in GitHub Actions
- Update Go version to 1.23 to match go.mod requirements
- Fix version numbers that should have been bumped to 1.0.0 by release-please

## Context
The v1.0.0 release failed because:
1. The GitHub Actions workflow didn't generate templ templates before building
2. The version strings in the code weren't bumped by release-please

This PR fixes the immediate build issue and updates the versions manually. We'll monitor the next release to ensure release-please properly bumps the versions.