### PR TITLE
fix: update release-please configuration for Go version updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,5 +60,4 @@ dev:
 	air
 
 # Full build - templ, CSS, swagger, and Go binary
-full-build: templ css swagger
-	go build -o bin/meos-graphics ./cmd/meos-graphics
+full-build: templ css swagger build

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,7 +1,4 @@
 package version
 
 // Version is the current version of the application
-// x-release-please-start-version
-const Version = "1.0.0"
-
-// x-release-please-end
+const Version = "1.0.0" // x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,7 @@
       "prerelease": false,
       "extra-files": [
         {
-          "type": "generic",
+          "type": "go",
           "path": "internal/version/version.go"
         },
         {


### PR DESCRIPTION
## Summary
This PR fixes the release-please configuration to properly update version strings in Go files.

## Changes
- Change version.go extra-file type from 'generic' to 'go' in release-please config
- Update version marker format to single-line Go comment style (release-please standard for Go)
- Update Dockerfile to use Go 1.23 and generate swagger docs during build
- Fix Makefile full-build target to avoid duplicate build command

## Testing
Once this is merged, the next release-please PR should properly update:
- `internal/version/version.go` - the Version constant
- `cmd/meos-graphics/main.go` - the @version comment

## Note on Swagger Docs
The swagger docs remain in source control as they're needed at runtime. The Dockerfile now ensures they're regenerated during build to avoid any drift.