### PR TITLE
fix: use generic type with glob pattern for version.go updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,10 @@ Releases are fully automated via GitHub Actions:
 
 1. **release-please** monitors `main` branch
 2. Creates/updates a release PR when changes detected
-3. When release PR is merged:
+3. The release PR will automatically update version strings in:
+   - `internal/version/version.go` - Go constant
+   - `cmd/meos-graphics/main.go` - Swagger @version annotation
+4. When release PR is merged:
    - Creates GitHub release with changelog
    - Builds binaries for all platforms
    - Publishes Docker images to ghcr.io

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,8 +9,9 @@
       "prerelease": false,
       "extra-files": [
         {
-          "type": "go",
-          "path": "internal/version/version.go"
+          "type": "generic",
+          "path": "internal/version/version.go",
+          "glob": "const Version = \"{version}\" // x-release-please-version"
         },
         {
           "type": "generic",


### PR DESCRIPTION
Release-please needs the generic type with a glob pattern to properly update the Go constant in version.go. This should fix the issue where version strings aren't being updated in the release PRs.