### PR TITLE
fix: convert repository name to lowercase for Docker registry

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,6 +63,11 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: docker/setup-buildx-action@v3
         
+      - name: Convert repository name to lowercase
+        if: ${{ steps.release.outputs.release_created }}
+        id: repo
+        run: echo "name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+        
       - name: Build and push Docker image
         if: ${{ steps.release.outputs.release_created }}
         uses: docker/build-push-action@v5
@@ -71,8 +76,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ steps.release.outputs.tag_name }}
+            ghcr.io/${{ steps.repo.outputs.name }}:latest
+            ghcr.io/${{ steps.repo.outputs.name }}:${{ steps.release.outputs.tag_name }}
           labels: |
             org.opencontainers.image.title=MeOS Graphics API
             org.opencontainers.image.description=REST API server for MeOS orienteering software


### PR DESCRIPTION
## Summary
- Add a step to convert repository name to lowercase before using it in Docker tags
- Fixes the error "repository name must be lowercase" when pushing to ghcr.io

## Context
The GitHub Actions variable `${{ github.repository }}` returns "MetsaApp/meos-graphics" with uppercase letters, but Docker registries require lowercase names. This PR adds a conversion step to handle this automatically.

## Test plan
- [ ] PR checks pass
- [ ] After merging, the release workflow will complete successfully