### PR TITLE
fix: add packages write permission for Docker registry push

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   release-please:


### PR DESCRIPTION
## Summary
- Add `packages: write` permission to the release workflow to fix Docker push authorization

## Context
The release workflow was failing with a 403 Forbidden error when trying to push Docker images to GitHub Container Registry (ghcr.io). This was because the workflow was missing the required `packages: write` permission.

## Test plan
- [ ] PR checks pass
- [ ] After merging, the next release will successfully push Docker images to ghcr.io